### PR TITLE
尝试修复MTK菜单无线设置升级无法保存的问题

### DIFF
--- a/mtk/applications/mtk-luci-plugin/Makefile
+++ b/mtk/applications/mtk-luci-plugin/Makefile
@@ -71,5 +71,9 @@ define Package/mtk-luci-plugin/install
 	$(call Package/common/install,$(1),luci-app-webconsole)
 endef
 
+define Package/mtk-luci-plugin/conffiles
+        /etc/wireless/
+endef
+
 
 $(eval $(call BuildPackage,mtk-luci-plugin))

--- a/mtk/applications/mtk-luci-plugin/Makefile
+++ b/mtk/applications/mtk-luci-plugin/Makefile
@@ -72,7 +72,7 @@ define Package/mtk-luci-plugin/install
 endef
 
 define Package/mtk-luci-plugin/conffiles
-        /etc/wireless/
+        /etc/wireless/mt*/mt*.dat
 endef
 
 


### PR DESCRIPTION
尝试修复MTK菜单无线设置升级无法保存的问题，使：
/etc/wireless/mt7615/mt7615.1.2G.dat
/etc/wireless/mt7615/mt7615.1.5G.dat
两个文件能在升级中得以保存。请大佬看看是否合适。